### PR TITLE
Add basic usage string

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use trashcan::codegen::Emit;
 fn main() {
     let args = env::args_os().collect::<Vec<_>>();
     if args.len() <= 1 {
+        println!("tcc 0.1.0\nThe trashcan compiler\n\nUSAGE:\n    tcc source.tc [source2.tc ...]\n");
         return;
     }
 


### PR DESCRIPTION
Basic usage string with a hardcoded version number for now.
Do you see the command line options getting more complex? If so maybe it's a good idea to move to dedicated CLI crate like structopt. 